### PR TITLE
Fix: Handle Principal IDs in the front-end

### DIFF
--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -33,8 +33,8 @@ const main = async () => {
   const profiles = require("./data");
   profiles.forEach(async (profile) => {
     const linkedup = await getActor("linkedup");
-    const userId = await linkedup.create(profile);
-    console.log("...profile added", userId);
+    await linkedup.create(profile);
+    console.log("...profile added");
   });
 };
 

--- a/src/linkedup/public/main.js
+++ b/src/linkedup/public/main.js
@@ -9,7 +9,7 @@ import linkedup from "ic:canisters/linkedup";
 import {
   ownProfilePageTmpl,
   profilePageTmpl,
-  searchResultsPageTmpl
+  searchResultsPageTmpl,
 } from "./templates";
 import { injectHtml } from "./utils";
 
@@ -23,10 +23,16 @@ linkedup
   .__getAsset("index.html")
   .then(injectHtml)
   .then(() =>
-    $(document).ready(function() {
+    $(document).ready(function () {
       // Reveal animations.
       const wow = new WOW();
       wow.init();
+
+      const state = {
+        connection: [],
+        profile: {},
+        results: [],
+      };
 
       //
       function renderNavbar() {
@@ -39,7 +45,7 @@ linkedup
       }
 
       renderNavbar();
-      $(window).resize(function() {
+      $(window).resize(function () {
         renderNavbar();
       });
 
@@ -49,7 +55,7 @@ linkedup
         $(".intro").css("height", windowHeight);
       }
       renderIntro();
-      $(window).resize(function() {
+      $(window).resize(function () {
         renderIntro();
       });
 
@@ -59,12 +65,12 @@ linkedup
           "n&nbsp;autonomous",
           "&nbsp;transparent",
           "n&nbsp;unstoppable",
-          "&nbsp;tamperproof"
+          "&nbsp;tamperproof",
         ],
         typeSpeed: 50,
         backSpeed: 25,
         backDelay: 3000,
-        loop: true
+        loop: true,
       });
 
       // Disable submit button.
@@ -90,18 +96,15 @@ linkedup
 
       function renderOwnProfile() {
         clearAdminSections();
-        (async function() {
+        (async function () {
           try {
             const ownId = await linkedup.getOwnId();
             const data = await linkedup.get(ownId);
             data.connections = [];
-            $(".profile")
-              .html(ownProfilePageTmpl(data))
-              .show();
+            $(".profile").html(ownProfilePageTmpl(data)).show();
             data.connections = await linkedup.getConnections(ownId);
-            $(".profile")
-              .html(ownProfilePageTmpl(data))
-              .show();
+            state.connections = data.connections;
+            $(".profile").html(ownProfilePageTmpl(data)).show();
           } catch (err) {
             console.error(err);
           }
@@ -110,23 +113,20 @@ linkedup
 
       function renderProfile(userId) {
         clearAdminSections();
-        (async function() {
+        (async function () {
           try {
             let data = await linkedup.get(userId);
+            state.profile = data;
             data.connections = [];
             data.isConnected = true;
-            $(".profile")
-              .html(profilePageTmpl(data))
-              .show();
+            $(".profile").html(profilePageTmpl(data)).show();
             Promise.all([
               linkedup.isConnected(userId),
-              linkedup.getConnections(userId)
+              linkedup.getConnections(userId),
             ]).then(([isConnected, connections]) => {
               data.isConnected = isConnected;
               data.connections = connections;
-              $(".profile")
-                .html(profilePageTmpl(data))
-                .show();
+              $(".profile").html(profilePageTmpl(data)).show();
             });
           } catch (err) {
             console.error(err);
@@ -136,12 +136,9 @@ linkedup
 
       function renderEdit(userId) {
         clearAdminSections();
-        $(".edit")
-          .show()
-          .find("#first-name")
-          .focus();
+        $(".edit").show().find("#first-name").focus();
 
-        (async function() {
+        (async function () {
           let result = {};
           if (userId) {
             result = await linkedup.get(userId);
@@ -153,12 +150,11 @@ linkedup
       function renderSearch(term) {
         clearAdminSections();
 
-        (async function() {
+        (async function () {
           try {
             const results = await linkedup.search(term);
-            $(".search")
-              .html(searchResultsPageTmpl(results))
-              .show();
+            state.results = results;
+            $(".search").html(searchResultsPageTmpl(results)).show();
           } catch (err) {
             console.error(err);
           }
@@ -169,14 +165,14 @@ linkedup
         clearAdminSections();
         $(".connections").show();
 
-        (async function() {
+        (async function () {
           const ownId = linkedup.getOwnId();
           let connections = userId
             ? await linkedup.getConnections(userId)
             : await linkedup.getConnections(ownId);
           let message;
           if (connections.length) {
-            message = connections.map(profile => searchResultTmpl(profile));
+            message = connections.map((profile) => searchResultTmpl(profile));
           } else {
             message = "<div>You don't have any connections yet.";
           }
@@ -184,32 +180,18 @@ linkedup
         })();
       }
 
-      $("#edit-form").submit(function(event) {
+      $("#edit-form").submit(function (event) {
         event.preventDefault();
         const button = $(this).find('button[type="submit"]');
         disableSubmitButton(button);
 
-        const firstName = $(this)
-          .find("#first-name")
-          .val();
-        const lastName = $(this)
-          .find("#last-name")
-          .val();
-        const title = $(this)
-          .find("#title")
-          .val();
-        const company = $(this)
-          .find("#company")
-          .val();
-        const experience = $(this)
-          .find("#experience")
-          .val();
-        const education = $(this)
-          .find("#education")
-          .val();
-        const imgUrl = $(this)
-          .find("#imgUrl")
-          .val();
+        const firstName = $(this).find("#first-name").val();
+        const lastName = $(this).find("#last-name").val();
+        const title = $(this).find("#title").val();
+        const company = $(this).find("#company").val();
+        const experience = $(this).find("#experience").val();
+        const education = $(this).find("#education").val();
+        const imgUrl = $(this).find("#imgUrl").val();
 
         async function action() {
           // Call Profile's public methods without an API
@@ -220,7 +202,7 @@ linkedup
             company,
             experience,
             education,
-            imgUrl
+            imgUrl,
           });
           renderOwnProfile();
           enableSubmitButton(button, "Submit");
@@ -228,19 +210,19 @@ linkedup
         action();
       });
 
-      $("a#edit").click(function() {
+      $("a#edit").click(function () {
         renderEdit();
       });
 
-      $("a#profile").click(function() {
+      $("a#profile").click(function () {
         renderOwnProfile();
       });
 
-      $("a#connections").click(function() {
+      $("a#connections").click(function () {
         renderConnections();
       });
 
-      $("a#login").click(function() {
+      $("a#login").click(function () {
         $(".splash-view").slideUp(0, "linear");
         $(".admin-view").slideDown(250, "linear");
         renderOwnProfile();
@@ -251,7 +233,7 @@ linkedup
       const updateById = (selector, text) =>
         (document.querySelector(selector).innerHTML = text);
 
-      const updateForm = model => {
+      const updateForm = (model) => {
         const { id, firstName, lastName, title, company, experience } = model;
         updateById("#address", id);
         updateById("#first-name", firstName);
@@ -267,17 +249,19 @@ linkedup
         renderEdit();
       };
 
-      const connectWith = userId => {
+      const connectWith = (userId) => {
         try {
-          linkedup.connect(parseInt(userId, 10));
+          const profile = state.profile;
+          linkedup.connect(profile.id);
           renderOwnProfile();
         } catch (err) {
           console.error(err);
         }
       };
 
-      const showProfile = userId => {
-        renderProfile(parseInt(userId, 10));
+      const showProfile = (index) => {
+        const profile = state.results[index];
+        renderProfile(profile.id);
       };
 
       const search = () => {
@@ -289,7 +273,7 @@ linkedup
         connectWith,
         showProfile,
         search,
-        showEdit
+        showEdit,
       };
     })
   );

--- a/src/linkedup/public/templates.js
+++ b/src/linkedup/public/templates.js
@@ -1,11 +1,11 @@
-import { Converter } from 'showdown';
+import { Converter } from "showdown";
 const converter = new Converter();
 
 /**
  * Profile Page
  */
 
-export const ownProfilePageTmpl = data => `
+export const ownProfilePageTmpl = (data) => `
   <div class="lu_profile-page container">
     <div class="row">
       <div class="col-md-8">
@@ -21,15 +21,16 @@ export const ownProfilePageTmpl = data => `
   </div>
 `;
 
-export const profilePageTmpl = data => `
+export const profilePageTmpl = (data) => `
   <div class="lu_profile-page container">
     <div class="row">
       <div class="lu_main col-md-8">
         <h4 class="lu_section-header">Profile</h4>
         ${profileTmpl(data)}
-        ${data.isConnected
-          ? ""
-          : `<button class="lu_button lu_connect-button" onclick="actions.connectWith('${data.id}')">Connect</button>`
+        ${
+          data.isConnected
+            ? ""
+            : `<button class="lu_button lu_connect-button" onclick="actions.connectWith()">Connect</button>`
         }
       </div>
       <div class="col-md-4">
@@ -40,38 +41,43 @@ export const profilePageTmpl = data => `
   </div>
 `;
 
-const profileTmpl = data => `
+const profileTmpl = (data) => `
   <div class="lu_profile">
     <div class="lu_avatar"><img src="${data.imgUrl}" /></div>
     <div class="lu_details">
       <h3 class="lu_details_header">${data.firstName} ${data.lastName}</h3>
       <h4 class="lu_details_body">${data.title} at ${data.company}</h4>
     </div>
-    ${data.experience === ""
-      ? ""
-      : `
+    ${
+      data.experience === ""
+        ? ""
+        : `
         <div class="lu_experience">
           <h4 class="lu_section-header">Experience</h4>
           <div>${converter.makeHtml(data.experience)}</div>
         </div>
-      `}
-      ${data.education === ""
-      ? ""
-      : `
+      `
+    }
+      ${
+        data.education === ""
+          ? ""
+          : `
         <div class="lu_education">
           <h4 class="lu_section-header">Education</h4>
           <div>${converter.makeHtml(data.education)}</div>
         </div>
-      `}
+      `
+      }
   </div>
 `;
 
-const connectionsTmpl = data => (data && data.connections.length)
-  ? data.connections.map(connectionTmpl).join('')
-  : "No connections";
+const connectionsTmpl = (data) =>
+  data && data.connections.length
+    ? data.connections.map(connectionTmpl).join("")
+    : "No connections";
 
-const connectionTmpl = data => `
-  <a class="lu_connection" onclick="actions.showProfile('${data.id}')">
+const connectionTmpl = (data, index) => `
+  <a class="lu_connection" onclick="actions.showProfile(${index})">
     <div class="lu_avatar"><img src="${data.imgUrl}" /></div>
     <div class="lu_details">
       <h5 class="lu_details_header">${data.firstName} ${data.lastName}</h5>
@@ -84,19 +90,18 @@ const connectionTmpl = data => `
  * Search Results Page
  */
 
-export const searchResultsPageTmpl = data => `
+export const searchResultsPageTmpl = (data) => `
   <div class="lu_search-results-page container">
     <h4 class="lu_section-header">Search Results</h4>
     ${searchResultsTmpl(data)}
   </div>
 `;
 
-const searchResultsTmpl = data => (data && data.length)
-  ? data.map(searchResultTmpl).join('')
-  : "No results";
+const searchResultsTmpl = (data) =>
+  data && data.length ? data.map(searchResultTmpl).join("") : "No results";
 
-const searchResultTmpl = data => `
-  <a class="lu_search-result" onclick="actions.showProfile('${data.id}')">
+const searchResultTmpl = (data, index) => `
+  <a class="lu_search-result" onclick="actions.showProfile(${index})">
     <div class="lu_avatar"><img src="${data.imgUrl}" /></div>
     <div class="lu_details">
       <h4>${data.firstName} ${data.lastName}</h4>


### PR DESCRIPTION
**Overview**

Introduction of Principal IDs as the `id` type meant we couldn't use `profile.id` in the front-end in the same way. This PR introduces a naive application state for LinkedUp and manages actions that way.

**Changes**

- Declare an application state to store search results and connections
- Refer to search results / connections by their index instead of `profile.id`
- Prettier

_Note: Prettier wreaked havoc on formatting, so I'll explicitly call out changes as comments._