### PR TITLE
Allow query calls to connectd's public getConnections() method

### DIFF
--- a/src/connectd/main.mo
+++ b/src/connectd/main.mo
@@ -12,7 +12,7 @@ actor Connectd {
     graph.addEdge(userA, userB);
   };
 
-  public func getConnections(user: Vertex): async [Vertex] {
+  public query func getConnections(user: Vertex): async [Vertex] {
     graph.getAdjacent(user)
   };
 


### PR DESCRIPTION
getConnections() makes no state changes, allowing a query call should speed up inter-canister comms.