### PR TITLE
Using upper case output for the CRC

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ Open the canister frontend in your web browser.
 
 ```bash
 ID=$(xxd -u -p canisters/linkedup/_canister.id)
-CRC=$(python2 -c "import crc8;h=crc8.crc8();h.update('$ID'.decode('hex'));print(h.hexdigest())")
+CRC=$(python2 -c "import crc8;h=crc8.crc8();h.update('$ID'.decode('hex'));print(h.hexdigest().upper())")
 xdg-open "http://127.0.0.1:8000/?canisterId=ic:$ID$CRC"
 ```


### PR DESCRIPTION
Seems like a lowercase CRC suffix for the canister ID leads to problems when trying to follow the url. It should probably be uppercase by default.