### PR TITLE
Use dist directory for webpack/assets flow; update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Start the replica, then build and install the canisters.
 
 ```bash
 dfx start --background
+dfx canister create --all
 dfx build
 dfx canister install --all
 ```
@@ -23,7 +24,5 @@ dfx canister install --all
 Open the canister frontend in your web browser.
 
 ```bash
-ID=$(xxd -u -p canisters/linkedup/_canister.id)
-CRC=$(python2 -c "import crc8;h=crc8.crc8();h.update('$ID'.decode('hex'));print(h.hexdigest().upper())")
-xdg-open "http://127.0.0.1:8000/?canisterId=ic:$ID$CRC"
+xdg-open "http://127.0.0.1:8000/?canisterId=$(dfx canister id linkedup_assets)"
 ```

--- a/dfx.json
+++ b/dfx.json
@@ -12,7 +12,10 @@
         "entrypoint": "src/linkedup/public/main.js"
       },
       "type": "assets",
-      "source": ["src/linkedup/public"]
+      "source": [
+        "src/linkedup/public",
+        "dist/linkedup_assets"
+      ]
     }
   },
   "defaults": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,7 +46,7 @@ function generateWebpackConfigForCanister(name, info) {
     },
     output: {
       filename: "index.js",
-      path: path.join(outputRoot, "assets"),
+      path: path.join(__dirname, "dist", name),
     },
     plugins: [],
     module: {


### PR DESCRIPTION
- Put webpack output in dist directory.
- Copy assets from dist directory.
- Update readme with new dfx command steps.

<img width="736" alt="Screen Shot 2020-08-07 at 12 33 16 PM" src="https://user-images.githubusercontent.com/64809312/89681822-8a075e00-d8aa-11ea-9235-c23d55222729.png">
